### PR TITLE
new flink conf syntax and HA port

### DIFF
--- a/charts/flink/Chart.yaml
+++ b/charts/flink/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.4.2
 description: Apache Flink is an open source stream processing framework developed by the Apache Software Foundation.
 name: flink
-version: 0.2.0
+version: 0.3.0

--- a/charts/flink/templates/jobmanager-deployment.yaml
+++ b/charts/flink/templates/jobmanager-deployment.yaml
@@ -27,13 +27,15 @@ spec:
 {{ include "flink.command" . | indent 10 }}
           ports:
             - name: web
-              containerPort: {{ .Values.conf.web__port | default 8081 }}
+              containerPort: {{ index .Values.conf "web.port" }}
             - name: rpc
-              containerPort: {{ .Values.conf.jobmanager__rpc__port | default 6123}}
+              containerPort: {{ index .Values.conf "jobmanager.rpc.port" }}
             - name: blob
-              containerPort: {{ .Values.conf.blob__server__port | default 6124}}
+              containerPort: {{ index .Values.conf "blob.server.port" }}
             - name: query
-              containerPort: {{ .Values.conf.query__server__port | default 6125 }}
+              containerPort: {{ index .Values.conf "query.server.port" }}
+            - name: ha
+              containerPort: {{ index .Values.conf "high-availability.jobmanager.port" }}
 {{- include "flink.env" . | indent 10 }}
 {{ include "flink.volumeMounts" . | indent 10 }}
 {{ include "flink.volumes" . | indent 6 }}

--- a/charts/flink/templates/jobmanager-service.yaml
+++ b/charts/flink/templates/jobmanager-service.yaml
@@ -10,15 +10,16 @@ metadata:
 spec:
   type: {{ .Values.jobmanager.service }}
   ports:
-    - port: {{ .Values.conf.web__port | default 8081 }}
+    - port: {{ index .Values.conf "web.port" }}
       name: web
-    - port: {{ .Values.conf.jobmanager__rpc__port | default 6123 }}
+    - port: {{ index .Values.conf "jobmanager.rpc.port" }}
       name: rpc
-    - port: {{ .Values.conf.blob__server__port | default 6124}}
+    - port: {{ index .Values.conf "blob.server.port" }}
       name: blob
-    - port: {{ .Values.conf.query__server__port | default 6125 }}
+    - port: {{ index .Values.conf "query.server.port" }}
       name: query
-
+    - name: ha
+      port: {{ index .Values.conf "high-availability.jobmanager.port" }}
   selector:
     app: {{ include "flink.name" . }}-jobmanager
     release: {{ .Release.Name }}

--- a/charts/flink/templates/taskmanager-deployment.yaml
+++ b/charts/flink/templates/taskmanager-deployment.yaml
@@ -27,9 +27,9 @@ spec:
 {{ include "flink.command" . | indent 10 }}
           ports:
             - name: rpc
-              containerPort: {{ .Values.conf.taskmanager__rpc__port | default 6121 }}
+              containerPort: {{ index .Values.conf "taskmanager.rpc.port"  }}
             - name: data
-              containerPort: {{ .Values.conf.taskmanager__data__port | default 6122 }}
+              containerPort: {{ index .Values.conf "taskmanager.data.port" }}
 {{- include "flink.env" . | indent 10 }}
 {{ include "flink.volumeMounts" . | indent 10 }}
 {{ include "flink.volumes" . | indent 6 }}

--- a/charts/flink/templates/taskmanager-service.yaml
+++ b/charts/flink/templates/taskmanager-service.yaml
@@ -11,9 +11,9 @@ spec:
   type: {{ .Values.taskmanager.service }}
   ports:
     - name: rpc
-      port: {{ .Values.conf.taskmanager__rpc__port | default 6121 }}
+      port: {{ index .Values.conf "taskmanager.rpc.port"  }}
     - name: data
-      port: {{ .Values.conf.taskmanager__data__port | default 6122 }}
+      port: {{ index .Values.conf "taskmanager.data.port" }}
 
   selector:
     app: {{ include "flink.name" . }}-taskmanager

--- a/charts/flink/values.yaml
+++ b/charts/flink/values.yaml
@@ -9,10 +9,15 @@ image:
   tag: 1.4.2
   pullPolicy: IfNotPresent
 
-#in conf key, replace "." with "__"
 conf:
-  taskmanager__rpc__port:
-  taskmanager__data__port:
+  taskmanager.rpc.port: 6121
+  taskmanager.data.port: 6122
+  web.port: 8081
+  jobmanager.rpc.port: 6123
+  blob.server.port: 6124
+  query.server.port: 6125
+  high-availability.jobmanager.port: 50010
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
This PR changes the syntax for flink conf values, allowing to use yaml syntax (with dots) instead of double underscores. It also add HA port and changes how default are managed.