### PR TITLE
tdmq-db: move /dev/shm to emptyDir

### DIFF
--- a/charts/tdmq-db/Chart.yaml
+++ b/charts/tdmq-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tdmq-db
-version: 0.1.0
+version: 0.2.0
 appVersion: 11.3.0-1
 description: Chart for TDM's db. It is a customized version of the official PostgreSQL Helm chart.
 keywords:

--- a/charts/tdmq-db/templates/statefulset-slaves.yaml
+++ b/charts/tdmq-db/templates/statefulset-slaves.yaml
@@ -166,7 +166,7 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
-        {{- if .Values.resources.shmOnEmptyDir.enabled }}
+        {{- if .Values.global.postgresql.shmOnEmptyDir.enabled }}
         - name: dshm
           mountPath: /dev/shm
         {{- end }}
@@ -188,10 +188,10 @@ spec:
           mountPath: /bitnami/postgresql/conf
         {{- end }}
       volumes:
-      {{- if .Values.resources.shmOnEmptyDir.enabled }}
+      {{- if .Values.global.postgresql.shmOnEmptyDir.enabled }}
       - name: dshm
         emptyDir:
-          medium: memory
+          medium: "Memory"
       {{- end }}
       {{- if .Values.usePasswordFile }}
       - name: postgresql-password

--- a/charts/tdmq-db/templates/statefulset-slaves.yaml
+++ b/charts/tdmq-db/templates/statefulset-slaves.yaml
@@ -166,6 +166,10 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
+        {{- if .Values.resources.shmOnEmptyDir.enabled }}
+        - name: dshm
+          mountPath: /dev/shm
+        {{- end }}
         {{- if .Values.usePasswordFile }}
         - name: postgresql-password
           mountPath: /opt/bitnami/postgresql/secrets/
@@ -184,6 +188,11 @@ spec:
           mountPath: /bitnami/postgresql/conf
         {{- end }}
       volumes:
+      {{- if .Values.resources.shmOnEmptyDir.enabled }}
+      - name: dshm
+        emptyDir:
+          medium: memory
+      {{- end }}
       {{- if .Values.usePasswordFile }}
       - name: postgresql-password
         secret:

--- a/charts/tdmq-db/templates/statefulset.yaml
+++ b/charts/tdmq-db/templates/statefulset.yaml
@@ -275,7 +275,7 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
-        {{- if .Values.resources.shmOnEmptyDir.enabled }}
+        {{- if .Values.global.postgresql.shmOnEmptyDir.enabled }}
         - name: dshm
           mountPath: /dev/shm
         {{- end }}
@@ -362,10 +362,10 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
-      {{- if .Values.resources.shmOnEmptyDir.enabled }}
+      {{- if .Values.global.postgresql.shmOnEmptyDir.enabled }}
       - name: dshm
         emptyDir:
-          medium: memory
+          medium: "Memory"
       {{- end }}
       {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
       - name: postgresql-config

--- a/charts/tdmq-db/templates/statefulset.yaml
+++ b/charts/tdmq-db/templates/statefulset.yaml
@@ -275,6 +275,10 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
+        {{- if .Values.resources.shmOnEmptyDir.enabled }}
+        - name: dshm
+          mountPath: /dev/shm
+        {{- end }}
         {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d/
@@ -358,6 +362,11 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
+      {{- if .Values.resources.shmOnEmptyDir.enabled }}
+      - name: dshm
+        emptyDir:
+          medium: memory
+      {{- end }}
       {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
       - name: postgresql-config
         configMap:

--- a/charts/tdmq-db/values.yaml
+++ b/charts/tdmq-db/values.yaml
@@ -6,7 +6,9 @@
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 global:
-  postgresql: {}
+  postgresql:
+    shmOnEmptyDir:
+      enabled: false
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
@@ -288,8 +290,6 @@ slave:
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources:
-  shmOnEmptyDir:
-    enabled: true
   requests:
     memory: 256Mi
     cpu: 250m

--- a/charts/tdmq-db/values.yaml
+++ b/charts/tdmq-db/values.yaml
@@ -288,6 +288,8 @@ slave:
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources:
+  shmOnEmptyDir:
+    enabled: true
   requests:
     memory: 256Mi
     cpu: 250m


### PR DESCRIPTION
 move /dev/shm to emptyDir to allow larger postgresql shared memory space

Solution explained here:
https://docs.openshift.com/container-platform/3.6/dev_guide/shared_memory.html