### PR TITLE
tdmq: query DB in livenessProbe; use startupProbe instead of readines…

### DIFF
--- a/charts/tdmq/Chart.yaml
+++ b/charts/tdmq/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: TDM query service
 name: tdmq
-version: 0.5.0
+version: 0.5.1

--- a/charts/tdmq/templates/deployment.yaml
+++ b/charts/tdmq/templates/deployment.yaml
@@ -39,12 +39,17 @@ spec:
               mountPath: /etc/flask
           livenessProbe:
             httpGet:
-              path: /api/v0.0/
+              path: /api/v0.0/entity_types
               port: http
-          readinessProbe:
+            failureThreshold: 2
+            periodSeconds: 10
+          startupProbe:
             httpGet:
-              path: /api/v0.0/
+              path: /api/v0.0/entity_types
               port: http
+            failureThreshold: 10
+            initialDelaySeconds: 2
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
tdmq liveness probe was too simple to detect problems.  This PR replaces it with a simple but real query, which will detect more problems.  Ideally we should set up a specific health checking API call.

Also, this PR replaces the `readinessProbe` with a `startupProbe`, which is the better tool for the specific use case.